### PR TITLE
Fix Cloudflare deployment: export Durable Objects and update worker name

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -6,6 +6,9 @@
 import { DMRoom } from './dm-room.js';
 import { GroupRoom } from './group-room.js';
 
+// Export Durable Object classes for Cloudflare Workers runtime
+export { DMRoom, GroupRoom };
+
 // Constants
 const JWT_SECRET = 'your-jwt-secret-key-change-this-in-production';
 const JWT_EXPIRATION = 60 * 60 * 24; // 24 hours in seconds

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "chat-app"
+name = "project-espresso"
 main = "worker.js"
 compatibility_date = "2023-08-01"
 


### PR DESCRIPTION
- Export DMRoom and GroupRoom classes from worker.js entrypoint
- Update worker name from 'chat-app' to 'project-espresso' to match CI expectations
- Resolves 'Durable Objects not exported' deployment error