### PR TITLE
Fix runtime NullPointerException in LoginController

### DIFF
--- a/src/main/java/com/espresso/client/controllers/LoginController.java
+++ b/src/main/java/com/espresso/client/controllers/LoginController.java
@@ -76,6 +76,12 @@ public class LoginController implements Initializable {
      */
     public void setPrimaryStage(Stage primaryStage) {
         this.primaryStage = primaryStage;
+        // Set the title now that we have the stage
+        if (isLoginMode) {
+            showLoginPane();
+        } else {
+            showRegisterPane();
+        }
     }
     
     /**
@@ -100,7 +106,9 @@ public class LoginController implements Initializable {
         loginPane.setVisible(true);
         registerPane.setVisible(false);
         toggleModeButton.setText("Create Account");
-        primaryStage.setTitle("Espresso Chat - Login");
+        if (primaryStage != null) {
+            primaryStage.setTitle("Espresso Chat - Login");
+        }
     }
     
     /**
@@ -110,7 +118,9 @@ public class LoginController implements Initializable {
         loginPane.setVisible(false);
         registerPane.setVisible(true);
         toggleModeButton.setText("Back to Login");
-        primaryStage.setTitle("Espresso Chat - Register");
+        if (primaryStage != null) {
+            primaryStage.setTitle("Espresso Chat - Register");
+        }
     }
     
     /**


### PR DESCRIPTION
- Add null checks in showLoginPane() and showRegisterPane() methods to handle cases where primaryStage is not yet set
- Update setPrimaryStage() method to properly set window title after stage is assigned
- Resolves runtime error that occurred when initialize() was called before setPrimaryStage()

This fixes the application startup crash and allows the login screen to display properly.